### PR TITLE
Add since and pagination to get_vendor_product_vulnerabilities()

### DIFF
--- a/pyvulnerabilitylookup/api.py
+++ b/pyvulnerabilitylookup/api.py
@@ -155,14 +155,31 @@ class PyVulnerabilityLookup():
         r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'browse', vendor))))
         return r.json()
 
-    def get_vendor_product_vulnerabilities(self, vendor: str, product: str) -> list[str]:
+    def get_vendor_product_vulnerabilities(self, vendor: str, product: str, since: date | datetime | None=None) -> list[str]:
         '''Get the the vulnerabilities per vendor and a specific product
 
         :param vendor: A vendor owning products (must be in the known vendor list)
         :param product: A product owned by that vendor
+        :param since: The date from which to get vulnerabilities
         '''
-        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'search', vendor, product))))
-        return r.json()
+
+        params = {}
+        if since:
+            if isinstance(since, datetime):
+                since = since.date()
+            params['since'] = since.isoformat()
+
+        params['page'] = 1
+        params['per_page'] = 100
+        r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'search', vendor, product))), params=params)
+        res = r.json()
+        while r.json()['cvelistv5']:
+            params['page'] += 1
+            r = self.session.get(urljoin(self.root_url, str(PurePosixPath('api', 'vulnerability', 'search', vendor, product))), params=params)
+            for source in r.json():
+                res[source] = res.get(source, []) + r.json()[source]
+
+        return res
 
     # #### Comments ####
 


### PR DESCRIPTION
Hi,

This PR adds : 
* `since` parameter, exposed by the API, to the python binding;
* pagination, to retrieve all results matching the query.

I'm not very confident in the while condition to detect that we got all results, maybe another test would fit better ?

Cheers,
François